### PR TITLE
Remove constant to fix issue #8

### DIFF
--- a/lib/facter/windows_sid.rb
+++ b/lib/facter/windows_sid.rb
@@ -5,23 +5,22 @@
 #
 # Written to determine the computer SID for the current windows machine.
 #
-Facter.add('windows_sid') do
+Facter.add("windows_sid") do
   confine :kernel => :windows
   
-  sid = 'unknown'
+  productkey = "unknown"
   begin
     
-    if RUBY_PLATFORM.downcase.include?('mswin') or RUBY_PLATFORM.downcase.include?('mingw32')
+    if RUBY_PLATFORM.downcase.include?("mswin") or RUBY_PLATFORM.downcase.include?("mingw32")
       require 'win32/registry'
       
-      KEY_WOW64_64KEY = 0x100 unless defined? KEY_WOW64_64KEY
-      access = Win32::Registry::KEY_READ | KEY_WOW64_64KEY
+      access = Win32::Registry::KEY_READ | 0x100
       key = 'Software\Microsoft\Windows\CurrentVersion\Group Policy'
     
       Win32::Registry::HKEY_LOCAL_MACHINE.open(key, access) do |reg|
         reg.keys.each do |key|
           if key.start_with?('S-1-5-21')
-            sid = key.gsub(/-500$/,"")   
+            productkey = key.gsub(/-500$/,"")   
           end
         end
       end
@@ -31,6 +30,6 @@ Facter.add('windows_sid') do
   end
 
   setcode do
-    sid
+    productkey
   end
 end


### PR DESCRIPTION
Fixing issue where puppet was erroring out while creating the catalog:
'uninitialized constant PuppetX::Puppetlabs::Registry::KEY_WOW64_64KEY'.
This same constant conflicts with the puppetlags/registry module and was
reported as part of issue #3.
