### PR TITLE
Remove constant to fix issue #8

### DIFF
--- a/lib/facter/windows_sid.rb
+++ b/lib/facter/windows_sid.rb
@@ -14,8 +14,7 @@ Facter.add('windows_sid') do
     if RUBY_PLATFORM.downcase.include?('mswin') or RUBY_PLATFORM.downcase.include?('mingw32')
       require 'win32/registry'
       
-      KEY_WOW64_64KEY = 0x100 unless defined? KEY_WOW64_64KEY
-      access = Win32::Registry::KEY_READ | KEY_WOW64_64KEY
+      access = Win32::Registry::KEY_READ | 0x100
       key = 'Software\Microsoft\Windows\CurrentVersion\Group Policy'
     
       Win32::Registry::HKEY_LOCAL_MACHINE.open(key, access) do |reg|


### PR DESCRIPTION
Fixing issue where puppet was erroring out while creating the catalog:
'uninitialized constant PuppetX::Puppetlabs::Registry::KEY_WOW64_64KEY'.
This same constant conflicts with one from puppetlags/registry module and was
reported as part of issue #3.
